### PR TITLE
Add InertiaJS v2 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "eslint": "./node_modules/.bin/eslint app/resources/js/ js/ --ext .js,.vue --fix"
   },
   "peerDependencies": {
-    "@inertiajs/vue3": "^1.0.6",
+    "@inertiajs/vue3": "^1.0.6||^2.0",
     "vue": "^3.2.37",
     "tailwind-merge": "^2.2.0"
   },


### PR DESCRIPTION
I added the InertiaJS vue3 version 2 constraint to package.json. Looking at the changelog there were little breaking changes and after installing and testing locally in the browser all still seems to work.
